### PR TITLE
Required lib.php to prevent exception.

### DIFF
--- a/tab_responses.php
+++ b/tab_responses.php
@@ -16,6 +16,8 @@
 
 $pid = optional_param('pid', 0, PARAM_INTEGER);
 
+require_once(dirname(__FILE__) . '/lib.php');
+
 function poll_custom_callback($a, $b) {
     $counta = $a->responsecount;
     $countb = $b->responsecount;


### PR DESCRIPTION
```
Exception - Call to undefined function poll_sort_results()

Debug info: 
Error code: generalexceptionmessage

Stack trace:
line 51 of /blocks/poll/tab_responses.php: Error thrown
line 64 of /blocks/poll/tabs.php: call to require()
```

Edit: didn't think to bump the version number in `version.php` - I'll let you guys sort that out. :)